### PR TITLE
Use cgmath more consistently

### DIFF
--- a/game_gfx/src/lib.rs
+++ b/game_gfx/src/lib.rs
@@ -68,7 +68,7 @@ impl GfxDependencies{
 
 pub fn init_dependencies(window_deps: &mut WindowDependencies) -> GfxDependencies {
   let dimensions = window_deps.dimensions();
-  let frame = gfx::Frame::new(dimensions.x() as u16, dimensions.y() as u16);
+  let frame = gfx::Frame::new(dimensions.x, dimensions.y);
   let mut device = gfx_device_gl::GlDevice::new(|s| window_deps.window().get_proc_address(s));
   let program = device.link_program(VERTEX_SRC, FRAGMENT_SRC)
                       .ok().expect("Failed to link program");

--- a/game_window/Cargo.toml
+++ b/game_window/Cargo.toml
@@ -6,3 +6,4 @@ authors = ["Alex McArther <acmcarther@gmail.com>"]
 
 [dependencies]
 glfw = "*"
+cgmath = "*"

--- a/game_window/src/lib.rs
+++ b/game_window/src/lib.rs
@@ -1,24 +1,11 @@
 extern crate glfw;
+extern crate cgmath;
 
 use std::sync::mpsc::Receiver;
 
+pub use cgmath::Vector2;
 pub use glfw::{Action, Context, Key, WindowEvent};
 pub type Events = Receiver<(f64, glfw::WindowEvent)>;
-
-#[allow(dead_code)]
-pub struct DimensionsXY {
-  x: i32,
-  y: i32
-}
-
-impl DimensionsXY {
-  pub fn new(x: i32, y:i32) -> DimensionsXY {
-    DimensionsXY { x: x, y: y }
-  }
-
-  pub fn x(&self) -> i32 { self.x }
-  pub fn y(&self) -> i32 { self.y }
-}
 
 #[allow(dead_code)]
 pub struct WindowDependencies {
@@ -33,9 +20,9 @@ impl WindowDependencies {
     WindowDependencies { glfw: glfw, window: window, events: events}
   }
 
-  pub fn dimensions(&self) -> DimensionsXY {
+  pub fn dimensions(&self) -> Vector2<u16> {
     let (w, h) = self.window.get_framebuffer_size();
-    DimensionsXY::new(w, h)
+    Vector2::new(w as u16, h as u16)
   }
 
   pub fn swap_buffers(&mut self) {


### PR DESCRIPTION
Gets rid of the internal `DimensionsXY` type in favor of using cgmath.
